### PR TITLE
FIX: Check for component only if there is a Type selected

### DIFF
--- a/code/dataobjects/Link.php
+++ b/code/dataobjects/Link.php
@@ -91,7 +91,7 @@ class Link extends DataObject{
 			}elseif($this->Type == 'SiteTree'){
 				$this->Title = $this->SiteTree()->MenuTitle;
 			}else{
-				if($component = $this->getComponent($this->Type)){
+				if($this->Type && $component = $this->getComponent($this->Type)){
 					$this->Title = $component->Title;
 				}
 			}


### PR DESCRIPTION
If there is no Type on the Link, an 'Array to String' error will pop-up, since using DataObject->has_one() with no argument outputs all has_one components of the DataObject.
