### PR TITLE
Added URI encoding to formURL so it plays nicer with spaces

### DIFF
--- a/javascript/linkfield.js
+++ b/javascript/linkfield.js
@@ -11,7 +11,7 @@ jQuery.entwine("linkfield", function($) {
 			var formUrl = this.parents('form').attr('action'),
 				formUrlParts = formUrl.split('?'),
 				formUrl = formUrlParts[0],
-				url = formUrl + '/field/' + this.attr('name') + '/LinkFormHTML';
+				url = encodeURI(formUrl) + '/field/' + this.attr('name') + '/LinkFormHTML';
 
 			if(self.val().length){
 				url = url + '?LinkID=' + self.val();


### PR DESCRIPTION
If the selected GridField has spaces in it's Name and/or Title, the Link Window will display blank. Added encodeURI to the formURL variable so it converts spaces correctly.