### PR TITLE
Fix "Please select a SiteTree object to link to"

### DIFF
--- a/code/dataobjects/Link.php
+++ b/code/dataobjects/Link.php
@@ -200,7 +200,7 @@ class Link extends DataObject{
 				}
 			}
 		}else{
-			if($this->Type && !$this->getComponent($this->Type)->exists()){
+			if($this->Type && empty($this->{$this->Type.'ID'})){
 				$valid = false;
 				$message = _t('Linkable.VALIDATIONERROR_OBJECT', "Please select a {value} object to link to", array('value' => $this->Type));
 			}


### PR DESCRIPTION
On the initial save the SiteTree relation isn't actually saved yet to `->getComponent(...)->exists()` returns false.
While this doesn't validate that it's actually a valid relation ID it does allow you to save.

I'm not sure if this only comes into play when you has_many to Link or if it still affects has_one but it was on has_many when I noticed it.