### PR TITLE
The LinkField javascript was adding a path to the end of a querystring

### DIFF
--- a/javascript/linkfield.js
+++ b/javascript/linkfield.js
@@ -83,10 +83,12 @@ jQuery.entwine("linkfield", function($) {
 
 	$(".linkfield-remove-button").entwine({
 		onclick: function() {
-			var url = this.parents('form').attr('action') + '/field/' + this.siblings('input:first').prop('name') + '/doRemoveLink';
+			var link = document.createElement('a');
+			link.href = this.parents('form').attr('action');
+			link.pathname = link.pathname + '/field/' + this.siblings('input:first').prop('name') + '/doRemoveLink';
 			var holder = this.parents('.field:first');
 			this.parents('.middleColumn:first').html("<img src='framework/images/network-save.gif' />");
-			holder.load(url);
+			holder.load(link.href.toString());
 			return false;
 		},
 	});


### PR DESCRIPTION
There may be a query string on the end of a form action, particularly if
the Translatable module is present. Clicking the remove button was
failing in this case, for example.

This commit just adds the path to the end of the path portion of the URL
instead.