### PR TITLE
Added extension point (hook) to customise link template.

### DIFF
--- a/code/dataobjects/Link.php
+++ b/code/dataobjects/Link.php
@@ -168,7 +168,12 @@ class Link extends DataObject{
 			$title = $this->Title ? $this->Title : $url; // legacy
 			$target = $this->getTargetAttr();
 			$class = $this->getClassAttr();
-			return "<a href='$url' $target $class>$title</a>";
+
+			$link = "<a href='$url' $target $class>$title</a>";
+
+			$this->extend('updateLinkTemplate', $this, $link);
+
+		  	return $link;
 		}
 	}
 


### PR DESCRIPTION
I've added extension point (hook) to customise link template. This is helpful when you require extra markup e.g. icons, spans or whatever.

For example:

```php
public function updateLinkTemplate($originalLink, &$link)
    {
        if($url = $originalLink->getLinkURL()) {

            $title = $originalLink->Title ? $originalLink->Title : $url; // legacy
            $target = $originalLink->getTargetAttr();
            $class = $originalLink->getClassAttr();
            $icon = $originalLink->getIcon();
            $id = $originalLink->getIDAttr();

            $link = "<a href='$url' $target $class $id> $icon $title</a>";

            return $link;
        }
    }
```