### PR TITLE
Remove linkfield dialog once the modal window is closed

### DIFF
--- a/javascript/linkfield.js
+++ b/javascript/linkfield.js
@@ -62,7 +62,9 @@ jQuery.entwine("linkfield", function($) {
 				return false;
 			});
 		},
-
+		onunmatch: function () {
+			$('.linkfield-dialog').remove();
+		},
 		showDialog: function(url) {
 			var dlg = this.getDialog();
 
@@ -98,5 +100,3 @@ jQuery.entwine("linkfield", function($) {
 		},
 	});
 });
-
-


### PR DESCRIPTION
The Link Type dropdown disappears the second time the modal window for a different LinkField pops up.

So to reproduce the problem. Create two LinkFields, open the dialog for one and see that the Link Type shows up. Close it, navigate away (change tabs for example, anything that doesn't reload the page), and open the second LinkField: the Link Type disappears. It appears again when reloading the page.

The module creates two dialog elements, and the dropdownField Chose component doesn't handle that well (because there are not-unique ids now in the page).

To fix it I removed the linkfield dialog element once it's unmatch.