### PR TITLE
Multiple improvements to links

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ In your template, you can set the style to use by adding setStyle()
 $ExampleLink.setStyle('iconbutton')
 ```
 
-### Link selectable styles
+### Selectable link styles
 
 You can create styles for an administrator to select in a dropdown field.
 To add these styles in to the dropdown, define them in your site config.yaml file.
@@ -89,7 +89,7 @@ To add these styles in to the dropdown, define them in your site config.yaml fil
 Link:
   styles:
     button: Button
-    iconbutton: Button with icon
+    iconbutton: Description of button
 ```
 
 The example above will be rendered in Link_button.ss and Link_iconbutton.ss if available.

--- a/README.md
+++ b/README.md
@@ -17,61 +17,102 @@ This module contains a couple of handy FormFields / DataObjects for managing ext
 
 ## Installation with [Composer](https://getcomposer.org/)
 
-```composer require "sheadawson/silverstripe-linkable"```
+```
+composer require "sheadawson/silverstripe-linkable"
+```
 
 ## Link / LinkField
 
-A Link Object can be linked to a URL or, an internal Page or File in the SilverStripe instance. A DataObject, such as a Page can have many Link objects managed with a grid field, or one Link managed with LinkField. 
+A Link Object can be linked to a URL, Email, Phone number, an internal Page or File in the SilverStripe instance. A DataObject, such as a Page can have many Link objects managed with a grid field, or one Link managed with LinkField.
 
 ### Example usage
 
 ```php
 class Page extends SiteTree {
-	
+
 	private static $has_one = array(
 		'ExampleLink' => 'Link'
-	);		
+	);
 
 	public function getCMSFields(){
 		$fields = parent::getCMSFields();
-		
+
 		$fields->addFieldToTab('Root.Link', LinkField::create('ExampleLinkID', 'Link to page or file'));
-		
+
 		return $fields;
 	}
 }
 ```
 
 In your template, you can render the links anchor tag with
-	
-	$ExampleLink 
 
-Or roll your own tag, making sure that the url is set first to avoid broken links
+```html
+$ExampleLink
+```
+
+### Custom links/tags
+
+Roll your own tag, making sure that the url is set first to avoid broken links
 
 ```html
 <% if $ExampleLink.LinkURL %>
-	<a href="$ExampleLink.LinkURL" $ExampleLink.TargetAttr>$ExampleLink.Title</a>
+	<% with ExampleLink %>
+		<a href='{$LinkURL}'{$TargetAttr}{$ClassAttr}>{$Title}</a>
+	<% end_with %>
 <% end_if %>
 ```
 
+### Reusable custom link styles/tags
+
+Create a .ss file with the name Link_example.ss (replace "example" with your style name).
+
+Link_iconbutton.ss
+
+```html
+<a href='{$LinkURL}'{$TargetAttr}{$ClassAttr}>
+    <i class="fa fa-github" aria-hidden="true"></i>{$Title}
+</a>
+```
+
+In your template, you can set the style to use by adding setStyle()
+
+```html
+$ExampleLink.setStyle('iconbutton')
+```
+
+### Link selectable styles
+
+You can create styles for an administrator to select in a dropdown field.
+To add these styles in to the dropdown, define them in your site config.yaml file.
+
+```yaml
+Link:
+  styles:
+    button: Button
+    iconbutton: Button with icon
+```
+
+The example above will be rendered in Link_button.ss and Link_iconbutton.ss if available.
+If the template isn't available it will fall back by adding the style as a class to Link.ss
+
 ## EmbeddedObject/Field
 
-Use the EmbeddedObject/Field to easily add oEmbed content to a DataObject or Page. 
+Use the EmbeddedObject/Field to easily add oEmbed content to a DataObject or Page.
 
 ### Example usage
 
 ```php
 class Page extends SiteTree {
-	
+
 	private static $has_one = array(
 		'Video' => 'EmbeddedObject'
-	);		
+	);
 
 	public function getCMSFields(){
 		$fields = parent::getCMSFields();
-		
+
 		$fields->addFieldToTab('Root.Video', EmbeddedObjectField::create('Video', 'Video from oEmbed URL', $this->Video()));
-		
+
 		return $fields;
 	}
 }

--- a/code/dataobjects/EmbeddedObject.php
+++ b/code/dataobjects/EmbeddedObject.php
@@ -10,21 +10,21 @@
 class EmbeddedObject extends DataObject
 {
     private static $db = array(
-        'Title'                => 'Varchar(255)',
-        'Type'                => 'Varchar',
-        'SourceURL'            => 'Varchar(255)',
-        'Width'                => 'Varchar',
-        'Height'            => 'Varchar',
-        'Description'        => 'HTMLText',
-        'ThumbURL'            => 'Varchar(255)',
-        'ExtraClass'        => 'Varchar(64)',
-        'EmbedHTML'            => 'Text',
+        'Title' => 'Varchar(255)',
+        'Type' => 'Varchar',
+        'SourceURL' => 'Varchar(255)',
+        'Width' => 'Varchar',
+        'Height' => 'Varchar',
+        'Description' => 'HTMLText',
+        'ThumbURL' => 'Varchar(255)',
+        'ExtraClass' => 'Varchar(64)',
+        'EmbedHTML' => 'Text',
     );
 
     public function Embed()
     {
         $options = array(
-            'width'    => $this->Width,
+            'width' => $this->Width,
             'height' => $this->Height,
         );
         $this->setFromURL($this->SourceURL);

--- a/code/dataobjects/Link.php
+++ b/code/dataobjects/Link.php
@@ -9,6 +9,10 @@
  **/
 class Link extends DataObject
 {
+    /**
+     * @var string custom style for templates e.g Link_Button
+     */
+    protected $style;
 
     /**
      * @var string custom CSS classes for template
@@ -23,8 +27,10 @@ class Link extends DataObject
         'Type' => 'Varchar',
         'URL' => 'Varchar(255)',
         'Email' => 'Varchar(255)',
+        'Phone' => 'Varchar(255)',
         'Anchor' => 'Varchar(255)',
-        'OpenInNewWindow' => 'Boolean'
+        'OpenInNewWindow' => 'Boolean',
+        'SelectedStyle' => 'Varchar(255)'
     );
 
     /**
@@ -45,6 +51,14 @@ class Link extends DataObject
     );
 
     /**
+     * A map of styles that are available for templating
+     * Custom styles can be added to this
+     *
+     * @var array
+     */
+    private static $styles = array();
+
+    /**
      * A map of object types that can be linked to
      * Custom dataobjects can be added to this
      *
@@ -53,6 +67,7 @@ class Link extends DataObject
     private static $types = array(
         'URL' => 'URL',
         'Email' => 'Email address',
+        'Phone' => 'Phone number',
         'File' => 'File on this website',
         'SiteTree' => 'Page on this website'
     );
@@ -69,41 +84,108 @@ class Link extends DataObject
             'ajaxSafe' => true
         ));
 
+        $fields->removeByName(
+            array(
+                'SiteTreeID',
+                // seem to need to remove both of these for different SS versions...
+                'FileID',
+                'File',
+                'SelectedStyle',
+                'Anchor'
+            )
+        );
+
+        $styles = $this->config()->get('styles');
+        if ($styles) {
+            $i18nStyles = array();
+            foreach ($styles as $key => $label) {
+                $i18nStyles[$key] = _t('Linkable.STYLE'.strtoupper($key), $label);
+            }
+            $fields->addFieldToTab(
+                'Root.Main',
+                DropdownField::create(
+                    'Style',
+                    _t('Linkable.LINKSTYLE', 'Style'),
+                    $i18nStyles
+                )->setEmptyString('Default')
+            );
+        }
+
+        $fields->dataFieldByName('Title')
+            ->setTitle(_t('Linkable.TITLE', 'Title'))
+            ->setRightTitle(_t('Linkable.OPTIONALTITLE', 'Optional. Will be auto-generated from link if left blank'));
+
         $types = $this->config()->get('types');
         $i18nTypes = array();
         foreach ($types as $key => $label) {
             $i18nTypes[$key] = _t('Linkable.TYPE'.strtoupper($key), $label);
         }
+        $fields->replaceField(
+            'Type',
+            DropdownField::create(
+                'Type',
+                _t('Linkable.LINKTYPE', 'Link Type'),
+                $i18nTypes
+            )->setEmptyString(' '),
+            'OpenInNewWindow'
+        );
 
-        $fields->removeByName('SiteTreeID');
-        // seem to need to remove both of these for different SS versions...
-        $fields->removeByName('FileID');
-        $fields->removeByName('File');
+        $fields->addFieldsToTab(
+            'Root.Main',
+            CheckboxField::create(
+                'OpenInNewWindow',
+                _t('Linkable.OPENINNEWWINDOW','Open link in a new window')
+            )->displayIf('Type')->isEqualTo("URL")
+                ->orIf()->isEqualTo("File")
+                ->orIf()->isEqualTo("SiteTree")
+                ->end()
+        );
 
-        $fields->dataFieldByName('Title')->setTitle(_t('Linkable.TITLE', 'Title'))->setRightTitle(_t('Linkable.OPTIONALTITLE', 'Optional. Will be auto-generated from link if left blank'));
-        $fields->replaceField('Type', DropdownField::create('Type', _t('Linkable.LINKTYPE', 'Link Type'), $i18nTypes)->setEmptyString(' '), 'OpenInNewWindow');
+        $fields->addFieldsToTab(
+            'Root.Main',
+            array(
+                DisplayLogicWrapper::create(
+                    TreeDropdownField::create(
+                        'FileID',
+                        _t('Linkable.FILE', 'File'),
+                        'File',
+                        'ID',
+                        'Title'
+                    )
+                )->displayIf("Type")->isEqualTo("File")->end(),
 
-        $fields->addFieldToTab('Root.Main', DisplayLogicWrapper::create(
-            TreeDropdownField::create('FileID', _t('Linkable.FILE', 'File'), 'File', 'ID', 'Title')
-        )->displayIf("Type")->isEqualTo("File")->end());
+                DisplayLogicWrapper::create(
+                    TreeDropdownField::create(
+                        'SiteTreeID',
+                        _t('Linkable.PAGE', 'Page'),
+                        'SiteTree'
+                    ),
+                    TextField::create(
+                        'Anchor',
+                        _t('Linkable.ANCHOR', 'Anchor')
+                    )->setRightTitle(_t('Linkable.ANCHORINFO', 'Include # at the start of your anchor name'))
+                )->displayIf("Type")->isEqualTo("SiteTree")->end()
+            ),
+            'OpenInNewWindow'
+        );
 
-        $fields->addFieldToTab('Root.Main', DisplayLogicWrapper::create(
-            TreeDropdownField::create('SiteTreeID', _t('Linkable.PAGE', 'Page'), 'SiteTree')
-        )->displayIf("Type")->isEqualTo("SiteTree")->end());
+        $fields->dataFieldByName('URL')
+            ->displayIf("Type")->isEqualTo("URL");
 
-        $fields->addFieldToTab('Root.Main', $newWindow = CheckboxField::create('OpenInNewWindow', _t('Linkable.OPENINNEWWINDOW', 'Open link in a new window')));
-        $newWindow->displayIf('Type')->isNotEmpty();
+        $fields->dataFieldByName('Email')
+            ->setTitle(_t('Linkable.EMAILADDRESS', 'Email Address'))
+            ->displayIf("Type")
+            ->isEqualTo("Email");
 
-        $fields->dataFieldByName('URL')->displayIf("Type")->isEqualTo("URL");
-        $fields->dataFieldByName('Email')->setTitle(_t('Linkable.EMAILADDRESS', 'Email Address'))->displayIf("Type")->isEqualTo("Email");
+        $fields->dataFieldByName('Phone')
+            ->setTitle(_t('Linkable.PHONENUMBER', 'Phone Number'))
+            ->displayIf("Type")
+            ->isEqualTo("Phone");
 
         if ($this->SiteTreeID && !$this->SiteTree()->isPublished()) {
-            $fields->dataFieldByName('SiteTreeID')->setRightTitle(_t('Linkable.DELETEDWARNING', 'Warning: The selected page appears to have been deleted or unpublished. This link may not appear or may be broken in the frontend'));
+            $fields->dataFieldByName('SiteTreeID')
+                ->setRightTitle(_t('Linkable.DELETEDWARNING', 'Warning: The selected page appears to have been deleted or unpublished. This link may not appear or may be broken in the frontend'));
         }
-
-        $fields->addFieldToTab('Root.Main', $anchor = TextField::create('Anchor', _t('Linkable.ANCHOR', 'Anchor')), 'OpenInNewWindow');
-        $anchor->setRightTitle(_t('Linkable.ANCHORINFO', 'Include # at the start of your anchor name'));
-        $anchor->displayIf("Type")->isEqualTo("SiteTree");
 
         $this->extend('updateCMSFields', $fields);
 
@@ -120,14 +202,19 @@ class Link extends DataObject
     {
         parent::onAfterWrite();
         if (!$this->Title) {
-            if ($this->Type == 'URL' || $this->Type == 'Email') {
-                $this->Title = $this->{$this->Type};
-            } elseif ($this->Type == 'SiteTree') {
-                $this->Title = $this->SiteTree()->MenuTitle;
-            } else {
-                if ($this->Type && $component = $this->getComponent($this->Type)) {
-                    $this->Title = $component->Title;
-                }
+            switch ($this->Type) {
+                case 'URL':
+                case 'Email':
+                    $this->Title = $this->{$this->Type};
+                    break;
+                case 'SiteTree':
+                    $this->Title = $this->SiteTree()->MenuTitle;
+                    break;
+                default:
+                    if ($this->Type && $component = $this->getComponent($this->Type)) {
+                        $this->Title = $component->Title;
+                    }
+                    break;
             }
 
             if (!$this->Title) {
@@ -136,6 +223,18 @@ class Link extends DataObject
 
             $this->write();
         }
+    }
+
+    /**
+     * Add style to be used in CSS class and use template if its available
+     *
+     * @param string $style CSS class.
+     * @return Link
+     **/
+    public function setStyle($style)
+    {
+        $this->style = $style;
+        return $this;
     }
 
     /**
@@ -150,19 +249,6 @@ class Link extends DataObject
         return $this;
     }
 
-
-    /**
-     * Gets the html class attribute for this link.
-     *
-     * @return string
-     **/
-    public function getClassAttr()
-    {
-        $class = $this->cssClass ? Convert::raw2att($this->cssClass) : '';
-        return $class ? "class='$class'" : '';
-    }
-
-
     /**
      * Renders an HTML anchor tag for this link
      *
@@ -170,19 +256,15 @@ class Link extends DataObject
      **/
     public function forTemplate()
     {
-        if ($url = $this->getLinkURL()) {
-            $title = $this->Title ? $this->Title : $url; // legacy
-            $target = $this->getTargetAttr();
-            $class = $this->getClassAttr();
-
-            $link = "<a href='$url' $target $class>$title</a>";
-
-            $this->extend('updateLinkTemplate', $this, $link);
-
-            return $link;
+        if ($this->LinkURL) {
+            return $this->renderWith(
+                array(
+                    'Link_'.$this->Style, // Render link with this template if its found. eg Link_Button.ss
+                    'Link'
+                )
+            );
         }
     }
-
 
     /**
      * Works out what the URL for this link should be based on it's Type
@@ -194,23 +276,67 @@ class Link extends DataObject
         if (!$this->ID) {
             return;
         }
-        if ($this->Type == 'URL') {
-            return $this->URL;
-        } elseif ($this->Type == 'Email') {
-            return $this->Email ? "mailto:$this->Email" : null;
-        } else {
-            if ($this->Type && $component = $this->getComponent($this->Type)) {
-                if (!$component->exists()) {
-                    return false;
+        switch ($this->Type) {
+            case 'URL':
+                return $this->URL;
+            case 'Email':
+                return $this->Email ? "mailto:$this->Email" : null;
+            case 'Phone':
+                return $this->Phone ? "tel:$this->Phone" : null;
+            default:
+                if ($this->Type && $component = $this->getComponent($this->Type)) {
+                    if (!$component->exists()) {
+                        return false;
+                    }
+                    if ($component->hasMethod('Link')) {
+                        return $component->Link() . $this->Anchor;
+                    } else {
+                        return "Please implement a Link() method on your dataobject \"$this->Type\"";
+                    }
                 }
-
-                if ($component->hasMethod('Link')) {
-                    return $component->Link() . $this->Anchor;
-                } else {
-                    return "Please implement a Link() method on your dataobject \"$this->Type\"";
-                }
-            }
+                break;
         }
+    }
+
+    /**
+     * Gets the style
+     *
+     * @return string
+     **/
+    public function getStyle()
+    {
+        $style = $this->SelectedStyle ? : null;
+        if ($this->style) {
+            $style = Convert::raw2att($this->style);
+        }
+        return $style;
+    }
+
+    /**
+     * Gets the classes for this link.
+     *
+     * @return string
+     **/
+    public function getClasses()
+    {
+        $classes = explode(' ', $this->cssClass);
+        if ($this->Style) {
+            $classes[] = $this->Style;
+        }
+        $this->extend('updateClasses', $classes);
+        $classes = implode(' ', $classes);
+        return $classes;
+    }
+
+    /**
+     * Gets the html class attribute for this link.
+     *
+     * @return string
+     **/
+    public function getClassAttr()
+    {
+        $class = $this->Classes ? Convert::raw2att($this->Classes) : '';
+        return $class ? " class='$class'" : '';
     }
 
     /**
@@ -220,7 +346,7 @@ class Link extends DataObject
      **/
     public function getTargetAttr()
     {
-        return $this->OpenInNewWindow ? "target='_blank'" : '';
+        return $this->OpenInNewWindow ? " target='_blank'" : '';
     }
 
     /**
@@ -243,36 +369,52 @@ class Link extends DataObject
     {
         $valid = true;
         $message = null;
-        if ($this->Type == 'URL') {
-            if ($this->URL =='') {
-                $valid = false;
-                $message = _t('Linkable.VALIDATIONERROR_EMPTYURL', 'You must enter a URL for a link type of "URL"');
-            } else {
-                $allowedFirst = array('#', '/');
-                if (!in_array(substr($this->URL, 0, 1), $allowedFirst) && !filter_var($this->URL, FILTER_VALIDATE_URL)) {
+        $type = $this->Type;
+
+        // Check if empty strings
+        switch ($type) {
+            case 'URL':
+            case 'Email':
+            case 'Phone':
+                if ($this->{$type} =='') {
                     $valid = false;
-                    $message = _t('Linkable.VALIDATIONERROR_VALIDURL', 'Please enter a valid URL. Be sure to include http:// for an external URL. Or begin your internal url/anchor with a "/" character');
+                    $message = _t('Linkable.VALIDATIONERROR_EMPTY'.strtoupper($type), "You must enter a $type for a link type of \"$type\"");
                 }
-            }
-        } elseif ($this->Type == 'Email') {
-            if ($this->Email =='') {
-                $valid = false;
-                $message = _t('Linkable.VALIDATIONERROR_EMPTYEMAIL', 'You must enter an Email Address for a link type of "Email"');
-            } else {
-                if (!filter_var($this->Email, FILTER_VALIDATE_EMAIL)) {
+                break;
+            default:
+                if ($type && empty($this->{$type.'ID'})) {
                     $valid = false;
-                    $message = _t('Linkable.VALIDATIONERROR_VALIDEMAIL', 'Please enter a valid Email address');
+                    $message = _t('Linkable.VALIDATIONERROR_OBJECT', "Please select a {value} object to link to", array('value' => $type));
                 }
-            }
-        } else {
-            if ($this->Type && empty($this->{$this->Type.'ID'})) {
-                $valid = false;
-                $message = _t('Linkable.VALIDATIONERROR_OBJECT', "Please select a {value} object to link to", array('value' => $this->Type));
+                break;
+        }
+        // if its already failed don't bother checking the rest
+        if ($valid) {
+            switch ($type) {
+                case 'URL':
+                    $allowedFirst = array('#', '/');
+                    if (!in_array(substr($this->URL, 0, 1), $allowedFirst) && !filter_var($this->URL, FILTER_VALIDATE_URL)) {
+                        $valid = false;
+                        $message = _t('Linkable.VALIDATIONERROR_VALIDURL', 'Please enter a valid URL. Be sure to include http:// for an external URL. Or begin your internal url/anchor with a "/" character');
+                    }
+                    break;
+                case 'Email':
+                    if (!filter_var($this->Email, FILTER_VALIDATE_EMAIL)) {
+                        $valid = false;
+                        $message = _t('Linkable.VALIDATIONERROR_VALIDEMAIL', 'Please enter a valid Email address');
+                    }
+                    break;
+                case 'Phone':
+                    if (!preg_match("/^\+?[0-9]{3,4}[- ]{0,1}[0-9]{3,4}[- ]{0,1}[0-9]{4}$/", $this->Phone)) {
+                        $valid = false;
+                        $message = _t('Linkable.VALIDATIONERROR_VALIDPHONE', 'Please enter a valid Phone number');
+                    }
+                    break;
             }
         }
 
         $result = ValidationResult::create($valid, $message);
-        $this->extend('validate', $result);
+        $this->extend('updateValidate', $result);
         return $result;
     }
 }

--- a/code/dataobjects/Link.php
+++ b/code/dataobjects/Link.php
@@ -205,6 +205,7 @@ class Link extends DataObject
             switch ($this->Type) {
                 case 'URL':
                 case 'Email':
+                case 'Phone':
                     $this->Title = $this->{$this->Type};
                     break;
                 case 'SiteTree':

--- a/code/dataobjects/Link.php
+++ b/code/dataobjects/Link.php
@@ -258,12 +258,17 @@ class Link extends DataObject
     public function forTemplate()
     {
         if ($this->LinkURL) {
-            return $this->renderWith(
+            $link = $this->renderWith(
                 array(
                     'Link_'.$this->Style, // Render link with this template if its found. eg Link_Button.ss
                     'Link'
                 )
             );
+
+            // Redundent. Reccommended to use templating above.
+            $this->extend('updateLinkTemplate', $this, $link);
+
+            return $link;
         }
     }
 

--- a/templates/Link.ss
+++ b/templates/Link.ss
@@ -1,0 +1,1 @@
+<a href='{$LinkURL}'{$TargetAttr}{$ClassAttr}>{$Title}</a>


### PR DESCRIPTION
Multiple improvements to links.  Some changes may break links on sites, particularly if the site has extended links

- Added Phone Type
- Added Selectable styles that can be defined using extensions
- Cleaned code
- Fixed validation extend with “updateValidate”
- Link markup has been moved to templates.
- Link styles can use it own template if available.  e.g.
$Link.setStyle(‘button’) will use Link_button.ss