### PR TITLE
Make Embedded Object Fields hide-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,3 +165,16 @@ $Video.ThumbURL
 ```
 
 See EmbeddedObject.php for a list of properties saved available in $db.
+
+### Customising EmbeddedObjectField fields
+
+You can hide the description and/or the other fields, keeping only the URL and Thumbnail.
+
+In your config.yml
+
+```YAML
+EmbeddedObjectField:
+  hide_fields: true
+  hide_description: true
+```
+

--- a/code/forms/EmbeddedObjectField.php
+++ b/code/forms/EmbeddedObjectField.php
@@ -49,19 +49,40 @@ class EmbeddedObjectField extends FormField
             $properties['SourceURL'] = TextField::create($this->getName() . '[sourceurl]', '')->setAttribute('placeholder', _t('Linkable.SOURCEURL', 'Source URL'));
 
             if (strlen($this->object->SourceURL)) {
-                $properties['ObjectTitle'] = TextField::create($this->getName() . '[title]', _t('Linkable.TITLE', 'Title'));
-                $properties['Width'] = TextField::create($this->getName() . '[width]', _t('Linkable.WIDTH', 'Width'));
-                $properties['Height'] = TextField::create($this->getName() . '[height]', _t('Linkable.HEIGHT', 'Height'));
-                $properties['ThumbURL'] = HiddenField::create($this->getName() . '[thumburl]', '');
-                $properties['Type'] = HiddenField::create($this->getName() . '[type]', '');
-                if ($this->editableEmbedCode) {
-                    $properties['EmbedHTML'] = TextareaField::create($this->getName() . '[embedhtml]', 'Embed code');
-                } else {
-                    $properties['EmbedHTML'] = HiddenField::create($this->getName() . '[embedhtml]', '');
+                if(!EmbeddedObjectField::config()->hide_fields) {
+                    $properties['ObjectTitle'] = TextField::create($this->getName() . '[title]', _t('Linkable.TITLE', 'Title'));
+                    $properties['Width'] = TextField::create($this->getName() . '[width]', _t('Linkable.WIDTH', 'Width'));
+                    $properties['Height'] = TextField::create($this->getName() . '[height]', _t('Linkable.HEIGHT', 'Height'));
+                    $properties['ThumbURL'] = HiddenField::create($this->getName() . '[thumburl]', '');
+                    $properties['Type'] = HiddenField::create($this->getName() . '[type]', '');
+                    if ($this->editableEmbedCode) {
+                        $properties['EmbedHTML'] = TextareaField::create($this->getName() . '[embedhtml]', 'Embed code');
+                    } else {
+                        $properties['EmbedHTML'] = HiddenField::create($this->getName() . '[embedhtml]', '');
+                    }
+
+                    $properties['ExtraClass'] = TextField::create($this->getName() . '[extraclass]', _t('Linkable.CSSCLASS', 'CSS class'));
+                }
+                else {
+                    $properties['ObjectTitle'] = HiddenField::create($this->getName() . '[title]', _t('Linkable.TITLE', 'Title'));
+                    $properties['Width'] = HiddenField::create($this->getName() . '[width]', _t('Linkable.WIDTH', 'Width'));
+                    $properties['Height'] = HiddenField::create($this->getName() . '[height]', _t('Linkable.HEIGHT', 'Height'));
+                    $properties['ThumbURL'] = HiddenField::create($this->getName() . '[thumburl]', '');
+                    $properties['Type'] = HiddenField::create($this->getName() . '[type]', '');
+                    if ($this->editableEmbedCode) {
+                        $properties['EmbedHTML'] = HiddenField::create($this->getName() . '[embedhtml]', 'Embed code');
+                    } else {
+                        $properties['EmbedHTML'] = HiddenField::create($this->getName() . '[embedhtml]', '');
+                    }
+                    $properties['ExtraClass'] = HiddenField::create($this->getName() . '[extraclass]', _t('Linkable.CSSCLASS', 'CSS class'));
                 }
 
-                $properties['ObjectDescription'] = TextAreaField::create($this->getName() . '[description]', _t('Linkable.DESCRIPTION', 'Description'));
-                $properties['ExtraClass'] = TextField::create($this->getName() . '[extraclass]', _t('Linkable.CSSCLASS', 'CSS class'));
+                if(!EmbeddedObjectField::config()->hide_description) {
+                    $properties['ObjectDescription'] = TextAreaField::create($this->getName() . '[description]', _t('Linkable.DESCRIPTION', 'Description'));
+                }
+                else {
+                    $properties['ObjectDescription'] = HiddenField::create($this->getName() . '[description]', _t('Linkable.DESCRIPTION', 'Description'));
+                }
 
                 foreach ($properties as $key => $field) {
                     if ($key == 'ObjectTitle') {


### PR DESCRIPTION
This adds 2 simple config params to hide the description field (hide_description) and the other fields (hide_fields). Pretty handy - for me.