### PR TITLE
Fix LinkField to display the content on creating new

### DIFF
--- a/code/forms/LinkField.php
+++ b/code/forms/LinkField.php
@@ -123,7 +123,7 @@ class LinkField extends TextField
     {
         $requestID = Controller::curr()->request->requestVar('LinkID');
 
-        if ($requestID == '0') {
+        if ($requestID == '0' && !$this->Value()) {
             return;
         }
 


### PR DESCRIPTION
LinkField currently shows the link only after the parent object is saved. 