### PR TITLE
Change embed version to match the Silverstripe framework requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "silverstripe/vendor-plugin": "^1.0",
         "silverstripe/framework": "^4.0",
         "unclecheese/display-logic": "*",
-        "embed/embed": "^3.2"
+        "embed/embed": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.7"


### PR DESCRIPTION
Installing linkable with the latest 4.0 (4.0.3) was throwing a dependency error with embed.
Updating the version in linkable to match that in the framework allows it to install.