### PR TITLE
FIX: Catch Embed::create() exceptions to avoid errors from blocking entire pages

### DIFF
--- a/src/Models/EmbeddedObject.php
+++ b/src/Models/EmbeddedObject.php
@@ -4,6 +4,9 @@ namespace Sheadawson\Linkable\Models;
 
 use Embed\Adapters\Adapter;
 use Embed\Embed;
+use Psr\Log\LoggerInterface;
+use SilverStripe\Core\Convert;
+use SilverStripe\Core\Injector\Injector;
 use SilverStripe\ORM\DataObject;
 
 /**
@@ -71,13 +74,24 @@ class EmbeddedObject extends DataObject
 
     /**
      * @param $url
+     * @return void
      */
     public function setFromURL($url)
     {
         if ($url) {
-            // array('image' => array('minImageWidth' => $this->Width, 'minImageHeight' => $this->Height)));
-            $info = Embed::create($url);
-            $this->setFromEmbed($info);
+            try {
+                // array('image' => array('minImageWidth' => $this->Width, 'minImageHeight' => $this->Height)));
+                $info = Embed::create($url);
+                $this->setFromEmbed($info);
+            } catch (Exception $e) {
+                Injector::inst()->get(LoggerInterface::class)->warning(sprintf(
+                    'Couldn\'t retrieve embed from URL "%s", exception code %s, message "%s", trace "%s"',
+                    Convert::raw2xml($url),
+                    $e->getCode(),
+                    $e->getMessage(),
+                    str_replace("\n", ", ", $e->getTraceAsString())
+                ));
+            }
         }
     }
 


### PR DESCRIPTION
For example vimeo.com has quite a low rate limit, and anything that returns an HTTP 503 will throw an exception that isn't caught by this module and will generally cause pages to fail rendering, rather than the slightly nicer soft fail.

Not sure if this is a breaking change or not, I guess technically it might be (some people might prefer a hard-fail) but I thought I'd get your thoughts first.