### PR TITLE
Fix embedded object description fallback

### DIFF
--- a/src/Models/EmbeddedObject.php
+++ b/src/Models/EmbeddedObject.php
@@ -93,7 +93,7 @@ class EmbeddedObject extends DataObject
         $this->Width = $info->code->width;
         $this->Height = $info->code->height;
         $this->ThumbURL = $info->image->__toString();
-        $this->Description = $info->description ? $info->description : $info->Title;
+        $this->Description = $info->description ? $info->description : $info->title;
         $this->Type = $info->getOEmbed()->get('type');
         $embed = $info->code->html;
         $this->EmbedHTML = $embed ? $embed : $this->EmbedHTML;


### PR DESCRIPTION
Resolves 'No detector found for this value' when no description exists.