### PR TITLE
SS5 Upgrade: LinkField: Update "Save" to use the correct icon

### DIFF
--- a/src/Forms/LinkField.php
+++ b/src/Forms/LinkField.php
@@ -74,7 +74,7 @@ class LinkField extends TextField
         if (!$this->isFrontend) {
             $action
                 ->addExtraClass('ss-ui-action-constructive')
-                ->setAttribute('data-icon', 'accept');
+                ->setAttribute('data-icon', '!');
         }
 
         $link = null;


### PR DESCRIPTION
`data-icon` is used for the icon
Changes 
<img width="134" alt="image" src="https://github.com/user-attachments/assets/14e1758a-dec8-4a9d-a3d0-a59834488ea9" />  
To 
<img width="100" height="45" alt="image" src="https://github.com/user-attachments/assets/1cb64415-77ab-4f23-bc03-e70a4e834219" />
